### PR TITLE
Complete the Repos ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,13 @@ This top-level directory contains prototype, example and experiment projects dev
 
 ## Branching Strategy and Commit Rules
 
-To be completed...
+This repository uses a modified feature branch workflow. Where all big features are done on short-lived feature branches, and then merged into a development branch for final bug testing before being put through pull request (PR) into main. Although, if the change is quick enough to do in one setting and meets the commit requirements (talked about later) for the development branch the change can be committed directly to it.
+
+### Main: 
+The most stable copy of the current year's competition code. Code cannot be directly committed to this branch and instead it is required to use a PR. Before a PR is merged into main, a full test of the robot is required to make sure every feature works.
+
+### Development: 
+This branch houses all of the in-development features that aren't stable enough for main. Although, we should try our best to make sure that the current year's code in the development branch always works via quick testing on a mule or similar to make sure that any changes do not outright “brick” the robot. Pull requests are not required, but if you think a change should have a discussion feel free to make one.
+
+### Feature Branches: 
+Feature branches are short-lived branches to work on specific features, they should be named with this format: “YEAR-FEATURE_SHORTHAND”. An example is “2026-ground_pickup” which would be a feature branch for a ground pickup for the 2026 competition. These branches have no commit requirements and are not required to run or build. This is so we can upload our changes to the github at the end of sessions without losing it due to the chance of using a different computer. After a feature is completed, make sure to merge development into your branch and make sure that the robot still mostly works via a quick test. Once that is completed you can merge your branch into development and delete the feature branch.


### PR DESCRIPTION
I have finished drafting up the Branching Strategy and Commit Rules, I think it is at a stage where getting feedback would be good to make sure I did not miss or interpret anything wrong from our conversation on 1/10/2026. Please let me know if any changes you think it needs here, although I am unsure if I will complete the changes before todays (1/12/2026) meeting.

When I was doing this I remembered about GitHub issues as a useful tool for discussion and keeping track of tasks. I think we should have a conversation about our usage of issues and include our decision into the read-me before merging it into main. (I think using them would be useful to keep track of things during build season, instead of having stuff scattered around multiple google docs and photos of whiteboards. If we use them they shouldn't be forced and instead be an optional organization tool)